### PR TITLE
Specify individual GPU index

### DIFF
--- a/src/main.cu
+++ b/src/main.cu
@@ -346,6 +346,7 @@ int main(int argc, char **argv)
     LOG("Running gpu-miner version : %s\n", MINER_VERSION);
 
     int gpu_count = 0;
+    int used_devices = 0;
     cudaGetDeviceCount(&gpu_count);
     LOG("GPUs detected: %d\n", gpu_count);
     for (int i = 0; i < gpu_count; i++)
@@ -388,7 +389,7 @@ int main(int argc, char **argv)
                     exit(1);
                 }
                 use_device[device] = true;
-                gpu_count = 1;
+                used_devices += 1;
             }
             break;
         default:
@@ -397,16 +398,13 @@ int main(int argc, char **argv)
         }
     }
 
-    mining_workers_init(gpu_count);
-    setup_gpu_worker_count(gpu_count, gpu_count * parallel_mining_works_per_gpu);
+    mining_workers_init(gpu_count, use_device);
+    setup_gpu_worker_count(used_devices, used_devices * parallel_mining_works_per_gpu);
     LOG("will connect to broker @%s:%d\n", broker_ip, port);
 
     #ifdef __linux__
     signal(SIGPIPE, SIG_IGN);
     #endif
-
-    mining_workers_init(gpu_count);
-    setup_gpu_worker_count(gpu_count, gpu_count * parallel_mining_works_per_gpu);
 
     loop = uv_default_loop();
     uv_timer_init(loop, &reconnect_timer);

--- a/src/worker.h
+++ b/src/worker.h
@@ -156,11 +156,17 @@ void store_req_data(ssize_t worker_id, mining_worker_t *worker) {
     atomic_store(&(mining_req->worker), worker);
 }
 
-void mining_workers_init(int gpu_count) {
-    for (size_t i = 0; i < gpu_count * parallel_mining_works_per_gpu; i++) {
-        mining_worker_t *worker = mining_workers + i;
-        mining_worker_init(worker, (uint32_t) i, i % gpu_count);
-        store_req_data(i, worker);
+void mining_workers_init(int gpu_count, bool use_device[]) {
+    size_t worker_id = 0;
+    for (size_t i = 0; i < gpu_count; i++) {
+        if (use_device[i]) {
+            for(size_t j = 0; j < parallel_mining_works_per_gpu; j++) {
+                mining_worker_t *worker = mining_workers + worker_id;
+                mining_worker_init(worker, (uint32_t) worker_id, i);
+                store_req_data(worker_id, worker);
+                worker_id++;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Previously if you specified a particular GPU index it would use the first GPU available instead of the one desired.